### PR TITLE
Highlighting in Qautocompletetextbox fix

### DIFF
--- a/source/js/jquery.autocomplete.js
+++ b/source/js/jquery.autocomplete.js
@@ -430,7 +430,7 @@ $.Autocompleter.defaults = {
 	multiple: false,
 	multipleSeparator: ", ",
 	highlight: function(value, term) {
-		return value.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + term.replace(/([\^\$\(\)\[\]\{\}\*\.\+\?\|\\])/gi, "\\$1") + ")(?![^<>]*>)(?![^&;]+;)", "gi"), "<strong>$1</strong>");
+		return term==='' ? value : value.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + term.replace(/([\^\$\(\)\[\]\{\}\*\.\+\?\|\\])/gi, "\\$1") + ")(?![^<>]*>)(?![^&;]+;)", "gi"), "<strong>$1</strong>");
 	},
     scroll: true,
     scrollHeight: 180


### PR DESCRIPTION
Highlighting in Qautocompletetextbox puts an empty <strong></strong> before every letter. Not ideal and it breaks html entities.

So I changed it so it doesn't do the highlighting when there is nothing to highlight.